### PR TITLE
Add JS to close settings on outside click

### DIFF
--- a/webapp/assets/close_settings.js
+++ b/webapp/assets/close_settings.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function () {
+  function handleOutsideClick(event) {
+    var gBtn = document.getElementById('graph-settings-btn');
+    var gCollapse = document.getElementById('graph-settings-collapse');
+    if (gBtn && gCollapse && gCollapse.style.visibility === 'visible') {
+      if (!gCollapse.contains(event.target) && !gBtn.contains(event.target)) {
+        gBtn.click();
+      }
+    }
+    var aBtn = document.getElementById('advanced-settings-btn');
+    var aCollapse = document.getElementById('advanced-settings-collapse');
+    if (aBtn && aCollapse && aCollapse.style.visibility === 'visible') {
+      if (!aCollapse.contains(event.target) && !aBtn.contains(event.target)) {
+        aBtn.click();
+      }
+    }
+  }
+  document.addEventListener('click', handleOutsideClick);
+});


### PR DESCRIPTION
## Summary
- close settings panels when clicking outside

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'netmedex')*

------
https://chatgpt.com/codex/tasks/task_e_684e1626280c8333ad02a2b2de20d25c