### PR TITLE
Add node info display in cytoscape graph

### DIFF
--- a/webapp/assets/clientside_callback.js
+++ b/webapp/assets/clientside_callback.js
@@ -1,4 +1,95 @@
 window.dash_clientside = window.dash_clientside || {}
+
+function create_pmid_table(pmids, pmid_title) {
+  const pubtator_href = "https://www.ncbi.nlm.nih.gov/research/pubtator3/publication/"
+  const pmid_table = {
+    type: "Table",
+    namespace: "dash_html_components",
+    props: {
+      className: "table table-bordered table-striped table-sm",
+      children: [
+        {
+          type: "Thead",
+          namespace: "dash_html_components",
+          props: {
+            children: [
+              {
+                type: "Tr",
+                namespace: "dash_html_components",
+                props: {
+                  children: [
+                    {
+                      type: "Th",
+                      namespace: "dash_html_components",
+                      props: { children: "No." }
+                    },
+                    {
+                      type: "Th",
+                      namespace: "dash_html_components",
+                      props: { children: "PMID" }
+                    },
+                    {
+                      type: "Th",
+                      namespace: "dash_html_components",
+                      props: { children: "Title" }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: "Tbody",
+          namespace: "dash_html_components",
+          props: { children: [] }
+        }
+      ]
+    }
+  }
+
+  const table_entry = pmid_table.props.children[1].props.children
+  pmids.forEach((pmid, index) => {
+    const title = pmid_title[pmid]
+
+    table_entry.push({
+      type: "Tr",
+      namespace: "dash_html_components",
+      props: {
+        children: [
+          {
+            type: "Td",
+            namespace: "dash_html_components",
+            props: { children: `${index + 1}` }
+          },
+          {
+            type: "Td",
+            namespace: "dash_html_components",
+            props: {
+              children: {
+                type: "A",
+                namespace: "dash_html_components",
+                props: {
+                  href: pubtator_href + pmid,
+                  target: "_blank",
+                  children: pmid,
+                }
+              }
+            }
+          },
+          {
+            type: "Td",
+            namespace: "dash_html_components",
+            props: { children: `${title}` }
+          }
+        ]
+      }
+    })
+  })
+
+  return pmid_table
+}
+
 window.dash_clientside.clientside = {
   info_scroll: function (trigger) {
     const infoElements = document.querySelectorAll("[data-tooltip]")
@@ -40,7 +131,6 @@ window.dash_clientside.clientside = {
         return [{ "visibility": visibility, "zIndex": get_z_index(visibility) }, elements]
       }
 
-      const pubtator_href = "https://www.ncbi.nlm.nih.gov/research/pubtator3/publication/"
       const [node_1, node_2] = tap_edge.label.split(" (interacts with) ")
       let edge_type
       if (tap_edge.edge_type === "node") {
@@ -50,108 +140,76 @@ window.dash_clientside.clientside = {
       }
       elements.push({ props: { children: `${edge_type} 1: ${node_1}` }, type: "P", namespace: "dash_html_components" })
       elements.push({ props: { children: `${edge_type} 2: ${node_2}` }, type: "P", namespace: "dash_html_components" })
-      // elements.push({ props: { children: "Evidence:" }, type: "P", namespace: "dash_html_components" })
-      const edge_table = {
-        type: "Table",
-        namespace: "dash_html_components",
-        props: {
-          className: "table table-bordered table-striped table-sm",
-          children: [
-            {
-              type: "Thead",
-              namespace: "dash_html_components",
-              props: {
-                children: [
-                  {
-                    type: "Tr",
-                    namespace: "dash_html_components",
-                    props: {
-                      children: [
-                        {
-                          type: "Th",
-                          namespace: "dash_html_components",
-                          props: {
-                            children: "No.",
-                          }
-                        },
-                        {
-                          type: "Th",
-                          namespace: "dash_html_components",
-                          props: {
-                            children: "PMID",
-                          }
-                        },
-                        {
-                          type: "Th",
-                          namespace: "dash_html_components",
-                          props: {
-                            children: "Title",
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              type: "Tbody",
-              namespace: "dash_html_components",
-              props: {
-                children: [],
-              }
-            }
-          ]
-        }
-      }
-
-      const table_entry = edge_table.props.children[1].props.children
-      tap_edge.pmids.forEach((pmid, index) => {
-        const title = pmid_title[pmid]
-
-        table_entry.push({
-          type: "Tr",
-          namespace: "dash_html_components",
-          props: {
-            children: [
-              {
-                type: "Td",
-                namespace: "dash_html_components",
-                props: {
-                  children: `${index + 1}`,
-                }
-              },
-              {
-                type: "Td",
-                namespace: "dash_html_components",
-                props: {
-                  children: {
-                    type: "A",
-                    namespace: "dash_html_components",
-                    props: {
-                      href: pubtator_href + pmid,
-                      target: "_blank",
-                      children: pmid,
-                    }
-                  }
-                }
-              },
-              {
-                type: "Td",
-                namespace: "dash_html_components",
-                props: {
-                  children: `${title}`,
-                }
-              }
-            ]
-          }
-        })
-      })
-
+      const edge_table = create_pmid_table(tap_edge.pmids, pmid_title)
       visibility = "visible"
       elements.push(edge_table)
     }
 
+
+    return [{ "visibility": visibility, "zIndex": get_z_index(visibility) }, elements]
+  },
+  show_node_info: function (selected_nodes, tap_node, pmid_title) {
+    function check_if_selected(tap_node) {
+      for (let i = 0; i < selected_nodes.length; i++) {
+        if (selected_nodes[i].id === tap_node.id) {
+          return true
+        }
+      }
+      return false
+    }
+
+    function get_z_index(visibility) {
+      return visibility === "hidden" ? -100 : 100
+    }
+
+    let elements = []
+    let visibility = "hidden"
+
+    if (tap_node !== undefined) {
+      if (!check_if_selected(tap_node)) {
+        return [{ "visibility": visibility, "zIndex": get_z_index(visibility) }, elements]
+      }
+
+      elements.push({ props: { children: `Name: ${tap_node.label}` }, type: "P", namespace: "dash_html_components" })
+
+      let identifier = tap_node.standardized_id
+      const node_type = tap_node.node_type
+      let href = null
+
+      const NCBI_TAXONOMY = "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id="
+      const NCBI_GENE = "https://www.ncbi.nlm.nih.gov/gene/"
+      const NCBI_MESH = "https://meshb.nlm.nih.gov/record/ui?ui="
+
+      if (identifier !== "-" && identifier !== "") {
+        if (node_type === "Species") {
+          href = NCBI_TAXONOMY + identifier
+        } else if (node_type === "Gene") {
+          href = NCBI_GENE + identifier
+        } else if (node_type === "Chemical" || node_type === "Disease") {
+          href = NCBI_MESH + identifier
+        }
+      }
+
+      if (href) {
+        elements.push({
+          type: "P",
+          namespace: "dash_html_components",
+          props: {
+            children: ["Identifier: ", {
+              type: "A",
+              namespace: "dash_html_components",
+              props: { href: href, target: "_blank", children: identifier }
+            }]
+          }
+        })
+      } else {
+        elements.push({ props: { children: `Identifier: ${identifier}` }, type: "P", namespace: "dash_html_components" })
+      }
+
+      const node_table = create_pmid_table(tap_node.pmids, pmid_title)
+      visibility = "visible"
+      elements.push(node_table)
+    }
 
     return [{ "visibility": visibility, "zIndex": get_z_index(visibility) }, elements]
   }

--- a/webapp/assets/index.css
+++ b/webapp/assets/index.css
@@ -183,6 +183,19 @@ a:hover {
     box-shadow: 1px 1px 10px 1px rgba(0, 0, 0, 0.2);
 }
 
+#node-info-container {
+    position: relative;
+    overflow-y: auto;
+    height: 200px;
+    border-right: 10px;
+    display: inline-block;
+    background-color: whitesmoke;
+    border-radius: 4px;
+    padding: 0 5px;
+    margin-right: 5px;
+    box-shadow: 1px 1px 10px 1px rgba(0, 0, 0, 0.2);
+}
+
 #legend-container {
     padding: 5px;
     background-color: var(--MAIN-BACKGROUND);
@@ -194,11 +207,23 @@ a:hover {
     width: 100%;
 }
 
+#node-info {
+    width: 100%;
+}
+
 #edge-info-container p {
     color: var(--GRAY-TEXT);
 }
 
+#node-info-container p {
+    color: var(--GRAY-TEXT);
+}
+
 #edge-info-container h5 {
+    color: var(--TEXT);
+}
+
+#node-info-container h5 {
     color: var(--TEXT);
 }
 

--- a/webapp/callbacks/graph_update.py
+++ b/webapp/callbacks/graph_update.py
@@ -179,3 +179,13 @@ def callbacks(app):
         State("pmid-title-dict", "data"),
         prevent_initial_call=True,
     )
+
+    clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name="show_node_info"),
+        Output("node-info-container", "style"),
+        Output("node-info", "children"),
+        Input("cy", "selectedNodeData"),
+        State("cy", "tapNodeData"),
+        State("pmid-title-dict", "data"),
+        prevent_initial_call=True,
+    )

--- a/webapp/components/graph_info.py
+++ b/webapp/components/graph_info.py
@@ -29,6 +29,17 @@ edge_info = html.Div(
 )
 
 
+node_info = html.Div(
+    [
+        html.H5("Node Info", className="text-center"),
+        html.Div(id="node-info"),
+    ],
+    id="node-info-container",
+    className="flex-grow-1",
+    style=visibility.hidden,
+)
+
+
 legend = html.Div(
     [
         create_legend_box("icon_species.svg", "Species"),
@@ -43,4 +54,4 @@ legend = html.Div(
     id="legend-container",
 )
 
-graph_info = html.Div([edge_info, legend], id="bottom-container", className="d-flex")
+graph_info = html.Div([edge_info, node_info, legend], id="bottom-container", className="d-flex")


### PR DESCRIPTION
## Summary
- display node info on click and refactor js pmid table creation
- add node info container component and styling
- wire up callback to trigger new clientside function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_684e24ed349c8333af2894c5bc96ccc7